### PR TITLE
Dashboard process cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ http://localhost:8080
 ```
 ⚠️ Replace 8080 with any available local port.
 
+Step 4: When you are finished, press `Ctrl-C` in the terminal running WEPP. The command remains active while the dashboard is available and stops both dashboard services when interrupted.
+
 **Option 2: Visualize results on your local machine (requires Docker)**\
 You can also analyze your samples with WEPP on a server and run the dashboard locally.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ chmod +x run-wepp
 ```bash
 echo "
 run-wepp() {
-    snakemake -s $PWD/workflow/Snakefile \"\$@\"
+    \"$PWD/run-wepp\" \"\$@\"
 }
 export -f run-wepp
 " >> ~/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN /root/miniforge3/bin/conda init bash && \
 RUN pip install snakemake
 
 RUN echo 'run-wepp() {' >> /root/.bashrc && \
-    echo '    /root/miniforge3/bin/snakemake -s /workspace/workflow/Snakefile "$@"' >> /root/.bashrc && \
+    echo '    /workspace/run-wepp "$@"' >> /root/.bashrc && \
     echo '}' >> /root/.bashrc && \
     echo 'export -f run-wepp' >> /root/.bashrc
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,7 +96,7 @@ chmod +x run-wepp
 ```bash
 echo "
 run-wepp() {
-    snakemake -s $PWD/workflow/Snakefile \"\$@\"
+    \"$PWD/run-wepp\" \"\$@\"
 }
 export -f run-wepp
 " >> ~/.bashrc

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,8 @@ http://localhost:8080
 !!!Note
     ⚠️ Replace 8080 with any available local port.
 
+Step 4: When you are finished, press `Ctrl-C` in the terminal running WEPP. The command remains active while the dashboard is available and stops both dashboard services when interrupted.
+
 **Option 2: Visualize results on your local machine (requires Docker)**
 
 You can also analyze your samples with WEPP on a server and run the dashboard locally.

--- a/run-wepp
+++ b/run-wepp
@@ -1,5 +1,103 @@
 #!/bin/bash
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WEPP_DASHBOARD_PATH="$(pwd)/runtime"
+READY_FILE="$WEPP_DASHBOARD_PATH/dashboard.ready"
 
-exec snakemake -s "$REPO_ROOT/workflow/Snakefile" "$@"
+rm -f "$READY_FILE"
+
+snakemake -s "$REPO_ROOT/workflow/Snakefile" "$@"
+SNAKEMAKE_STATUS=$?
+
+if [ "$SNAKEMAKE_STATUS" -ne 0 ]; then
+    exit "$SNAKEMAKE_STATUS"
+fi
+
+if [ ! -f "$READY_FILE" ]; then
+    exit 0
+fi
+
+FRONTEND_PORT=$(cat "$READY_FILE")
+BACKEND_PID_FILE="$WEPP_DASHBOARD_PATH/dashboard.pid"
+NGINX_PID_FILE="$WEPP_DASHBOARD_PATH/nginx.pid"
+BACKEND_PID=""
+NGINX_PID=""
+
+if [ -f "$BACKEND_PID_FILE" ]; then
+    BACKEND_PID=$(cat "$BACKEND_PID_FILE")
+fi
+if [ -f "$NGINX_PID_FILE" ]; then
+    NGINX_PID=$(cat "$NGINX_PID_FILE")
+fi
+
+pid_is_running() {
+    case "$1" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+
+    PID_STATE=$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')
+    case "$PID_STATE" in
+        ""|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+remove_owned_pid_file() {
+    PID_FILE=$1
+    EXPECTED_PID=$2
+    if [ -n "$EXPECTED_PID" ] && [ -f "$PID_FILE" ] && \
+        [ "$(cat "$PID_FILE")" = "$EXPECTED_PID" ]; then
+        rm -f "$PID_FILE"
+    fi
+}
+
+cleanup_dashboard() {
+    EXIT_CODE=$?
+    trap - EXIT INT TERM
+
+    for PID in "$NGINX_PID" "$BACKEND_PID"; do
+        if pid_is_running "$PID"; then
+            kill -TERM "$PID" 2>/dev/null || true
+        fi
+    done
+
+    for _ in 1 2 3 4 5; do
+        if ! pid_is_running "$BACKEND_PID" && ! pid_is_running "$NGINX_PID"; then
+            break
+        fi
+        sleep 1
+    done
+
+    for PID in "$NGINX_PID" "$BACKEND_PID"; do
+        if pid_is_running "$PID"; then
+            kill -KILL "$PID" 2>/dev/null || true
+        fi
+    done
+
+    remove_owned_pid_file "$BACKEND_PID_FILE" "$BACKEND_PID"
+    remove_owned_pid_file "$NGINX_PID_FILE" "$NGINX_PID"
+    rm -f "$READY_FILE"
+    exit "$EXIT_CODE"
+}
+
+trap cleanup_dashboard EXIT
+trap 'exit 0' INT
+trap 'exit 143' TERM
+
+if ! pid_is_running "$BACKEND_PID" || ! pid_is_running "$NGINX_PID"; then
+    echo "Dashboard services exited before lifecycle handoff." >&2
+    exit 1
+fi
+
+echo -e "\n\n\nDASHBOARD IS RUNNING AT http://localhost:$FRONTEND_PORT (OR YOUR FORWARDED HOST PORT).\nPress Ctrl-C to stop the dashboard.\n\n\n"
+
+while pid_is_running "$BACKEND_PID" && pid_is_running "$NGINX_PID"; do
+    sleep 1
+done
+
+if ! pid_is_running "$BACKEND_PID"; then
+    echo "Dashboard backend exited unexpectedly." >&2
+else
+    echo "nginx exited unexpectedly." >&2
+fi
+exit 1

--- a/workflow/rules/dashboard.smk
+++ b/workflow/rules/dashboard.smk
@@ -115,6 +115,7 @@ rule dashboard_serve:
 
             export WEPP_DASHBOARD_PATH="$(pwd)/runtime"
             mkdir -p "$WEPP_DASHBOARD_PATH"
+            rm -f "$WEPP_DASHBOARD_PATH/dashboard.ready"
 
             BACKEND_PID=""
             NGINX_PID=""
@@ -172,6 +173,7 @@ rule dashboard_serve:
 
                 remove_owned_pid_file "$WEPP_DASHBOARD_PATH/dashboard.pid" "$BACKEND_PID"
                 remove_owned_pid_file "$WEPP_DASHBOARD_PATH/nginx.pid" "$NGINX_PID"
+                rm -f "$WEPP_DASHBOARD_PATH/dashboard.ready"
                 exit "$EXIT_CODE"
             }}
 
@@ -295,22 +297,12 @@ rule dashboard_serve:
                     sleep 1
                 done
                 if lsof -i :$FRONTEND_PORT >/dev/null 2>&1; then
-                    echo -e "\n\n\nDASHBOARD IS RUNNING AT http://localhost:$FRONTEND_PORT (OR YOUR FORWARDED HOST PORT).\nPress Ctrl-C to stop the dashboard.\n\n\n"
+                    cp {params.log} {output}
+                    printf '%s\n' "$FRONTEND_PORT" > "$WEPP_DASHBOARD_PATH/dashboard.ready"
                 else
                     echo -e "\n\n\nDASHBOARD NOT DETECTED ON PORT $FRONTEND_PORT. \n\n\n"
                     exit 1
                 fi
-
-                while kill -0 "$BACKEND_PID" 2>/dev/null && kill -0 "$NGINX_PID" 2>/dev/null; do
-                    sleep 1
-                done
-
-                if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
-                    echo "Dashboard backend exited unexpectedly." | tee -a {params.log}
-                else
-                    echo "nginx exited unexpectedly." | tee -a {params.log}
-                fi
-                exit 1
 
         else
             rm -f {input.taxonium_jsonl}
@@ -318,5 +310,9 @@ rule dashboard_serve:
 
         fi
 
-        cp {params.log} {output}
+        if [ "{params.dashboard}" = "True" ]; then
+            trap - EXIT INT TERM
+        else
+            cp {params.log} {output}
+        fi
         """

--- a/workflow/rules/dashboard.smk
+++ b/workflow/rules/dashboard.smk
@@ -116,6 +116,69 @@ rule dashboard_serve:
             export WEPP_DASHBOARD_PATH="$(pwd)/runtime"
             mkdir -p "$WEPP_DASHBOARD_PATH"
 
+            BACKEND_PID=""
+            NGINX_PID=""
+
+            pid_is_running() {{
+                PID_STATE=$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')
+                case "$PID_STATE" in
+                    ""|Z*) return 1 ;;
+                    *) return 0 ;;
+                esac
+            }}
+
+            remove_owned_pid_file() {{
+                PID_FILE=$1
+                EXPECTED_PID=$2
+                if [ -n "$EXPECTED_PID" ] && [ -f "$PID_FILE" ] && \
+                    [ "$(cat "$PID_FILE")" = "$EXPECTED_PID" ]; then
+                    rm -f "$PID_FILE"
+                fi
+            }}
+
+            cleanup_dashboard() {{
+                EXIT_CODE=$?
+                trap - EXIT INT TERM
+
+                for PID in "$NGINX_PID" "$BACKEND_PID"; do
+                    if [ -n "$PID" ] && pid_is_running "$PID"; then
+                        kill -TERM "$PID" 2>/dev/null || true
+                    fi
+                done
+
+                for _ in 1 2 3 4 5; do
+                    BACKEND_RUNNING=False
+                    NGINX_RUNNING=False
+                    if [ -n "$BACKEND_PID" ] && pid_is_running "$BACKEND_PID"; then
+                        BACKEND_RUNNING=True
+                    fi
+                    if [ -n "$NGINX_PID" ] && pid_is_running "$NGINX_PID"; then
+                        NGINX_RUNNING=True
+                    fi
+                    if [ "$BACKEND_RUNNING" = "False" ] && [ "$NGINX_RUNNING" = "False" ]; then
+                        break
+                    fi
+                    sleep 1
+                done
+
+                for PID in "$NGINX_PID" "$BACKEND_PID"; do
+                    if [ -n "$PID" ] && pid_is_running "$PID"; then
+                        kill -KILL "$PID" 2>/dev/null || true
+                    fi
+                    if [ -n "$PID" ]; then
+                        wait "$PID" 2>/dev/null || true
+                    fi
+                done
+
+                remove_owned_pid_file "$WEPP_DASHBOARD_PATH/dashboard.pid" "$BACKEND_PID"
+                remove_owned_pid_file "$WEPP_DASHBOARD_PATH/nginx.pid" "$NGINX_PID"
+                exit "$EXIT_CODE"
+            }}
+
+            trap cleanup_dashboard EXIT
+            trap 'exit 130' INT
+            trap 'exit 143' TERM
+
             # Check if running inside Docker
             if [ -f /.dockerenv ]; then
                 IN_DOCKER=True
@@ -134,7 +197,7 @@ rule dashboard_serve:
                 DASH_PID=$(cat "$WEPP_DASHBOARD_PATH/dashboard.pid")
                 if kill -0 "$DASH_PID" 2>/dev/null; then
                     echo -e "Existing dashboard running with PID $DASH_PID. Killing it safely."
-                    kill -9 "$DASH_PID" || true
+                    kill -TERM "$DASH_PID" || true
                 else
                     echo -e "dashboard.pid found, but process $DASH_PID not running. Cleaning up file."
                 fi
@@ -173,7 +236,11 @@ rule dashboard_serve:
             # Wait until Node.js server opens port $BACKEND_PORT
             # ──────────────────────────────────────────────
             until lsof -i :$BACKEND_PORT >/dev/null 2>&1; do
-                # echo "Waiting for Node.js server to start..."
+                if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+                    echo "Dashboard backend exited before opening port $BACKEND_PORT." | tee -a {params.log}
+                    wait "$BACKEND_PID" || true
+                    exit 1
+                fi
                 sleep 1
             done
 
@@ -185,8 +252,7 @@ rule dashboard_serve:
                 NGINX_PID=$(cat "$WEPP_DASHBOARD_PATH/nginx.pid")
                 if kill -0 "$NGINX_PID" 2>/dev/null; then
                     echo "Existing nginx running with PID $NGINX_PID.  Killing it safely." | tee -a {params.log}
-                    kill -9 "$NGINX_PID" || true
-                    kill -9 $((NGINX_PID + 1)) || true
+                    kill -TERM "$NGINX_PID" || true
                 else
                     echo "nginx.pid found, but process $NGINX_PID not running. Cleaning up file."
                     rm -f "$WEPP_DASHBOARD_PATH/nginx.pid"
@@ -216,17 +282,35 @@ rule dashboard_serve:
                 > "$WEPP_DASHBOARD_PATH/wepp-nginx.conf"
 
                 cp {params.mime_types} $WEPP_DASHBOARD_PATH
-                nginx -c $WEPP_DASHBOARD_PATH/wepp-nginx.conf &
+                nginx -g 'daemon off;' -c "$WEPP_DASHBOARD_PATH/wepp-nginx.conf" &
+                NGINX_PID=$!
 
                 until lsof -i :$FRONTEND_PORT >/dev/null 2>&1; do
+                    if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+                        echo "nginx exited before opening port $FRONTEND_PORT." | tee -a {params.log}
+                        wait "$NGINX_PID" || true
+                        exit 1
+                    fi
                     echo -e "Waiting for nginx to start on port $FRONTEND_PORT..."
                     sleep 1
                 done
                 if lsof -i :$FRONTEND_PORT >/dev/null 2>&1; then
-                    echo -e "\n\n\nWORKFLOW COMPLETED! DASHBOARD IS RUNNING AT http://localhost:$FRONTEND_PORT (OR YOUR FORWARDED HOST PORT).\n\n\n"
+                    echo -e "\n\n\nDASHBOARD IS RUNNING AT http://localhost:$FRONTEND_PORT (OR YOUR FORWARDED HOST PORT).\nPress Ctrl-C to stop the dashboard.\n\n\n"
                 else
-                    echo -e "\n\n\nWORKFLOW COMPLETED, BUT DASHBOARD NOT DETECTED ON PORT $FRONTEND_PORT. \n\n\n"
+                    echo -e "\n\n\nDASHBOARD NOT DETECTED ON PORT $FRONTEND_PORT. \n\n\n"
+                    exit 1
                 fi
+
+                while kill -0 "$BACKEND_PID" 2>/dev/null && kill -0 "$NGINX_PID" 2>/dev/null; do
+                    sleep 1
+                done
+
+                if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+                    echo "Dashboard backend exited unexpectedly." | tee -a {params.log}
+                else
+                    echo "nginx exited unexpectedly." | tee -a {params.log}
+                fi
+                exit 1
 
         else
             rm -f {input.taxonium_jsonl}


### PR DESCRIPTION
## Summary

- Clean up Node, nginx, and owned PID files when dashboard startup fails or the workflow exits.
- Let Snakemake finish after starting the dashboard, then use `run-wepp` to monitor services and handle Ctrl-C without a `WorkflowError`.
- Route Docker and native installation commands through the lifecycle wrapper.

## Testing

- Confirmed the dashboard returns HTTP 200.
- Confirmed Ctrl-C exits with status 0 and leaves no dashboard processes or PID files.